### PR TITLE
Generate secret key in Chef

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -138,6 +138,19 @@ template "#{apache_dir}/httpd.conf" do
   })
 end
 
+template "#{apache_dir}/conf-available/cypress.conf" do
+  source "cypress-conf-available.conf.erb"
+  action :create_if_missing
+  sensitive true
+  variables({
+    :secret_key_base => SecureRandom.hex(64)
+  })
+end
+
+link "#{apache_dir}/conf-enabled/cypress.conf" do
+  to "#{apache_dir}/conf-available/cypress.conf"
+end
+
 rvm_shell "precompile assets" do
   cwd rails_app_path
   ruby_string node[:cypress][:ruby_version]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,6 +1,9 @@
 include_recipe "mongodb::10gen_repo"
 include_recipe "mongodb::default"
 include_recipe "rvm::system_install"
+
+require 'securerandom'
+
 rvm_default_ruby node[:cypress][:ruby_version]
 
 user_home = "/home/" + node[:cypress][:user]
@@ -131,13 +134,6 @@ link "#{apache_dir}/mods-enabled/cypress.conf" do
   to "#{apache_dir}/mods-available/cypress.conf"
 end
 
-template "#{apache_dir}/httpd.conf" do
-  source "httpd.conf.erb"
-  variables({
-    :servername => node[:cypress][:servername]
-  })
-end
-
 template "#{apache_dir}/conf-available/cypress.conf" do
   source "cypress-conf-available.conf.erb"
   action :create_if_missing
@@ -149,6 +145,13 @@ end
 
 link "#{apache_dir}/conf-enabled/cypress.conf" do
   to "#{apache_dir}/conf-available/cypress.conf"
+end
+
+template "#{apache_dir}/httpd.conf" do
+  source "httpd.conf.erb"
+  variables({
+    :servername => node[:cypress][:servername]
+  })
 end
 
 rvm_shell "precompile assets" do

--- a/templates/default/cypress-conf-available.conf.erb
+++ b/templates/default/cypress-conf-available.conf.erb
@@ -1,0 +1,1 @@
+SetEnv SECRET_KEY_BASE <%= @secret_key_base %>


### PR DESCRIPTION
There is a pull request in on Cypress that moves the secret key for production installs to an environment variable. This PR generates the secret key when first installing the app, by passing it to Apache, which passes it to Passenger and the rails app. This way it is generated randomly for each install, and is only generated if the file doesn't already exist.