### PR TITLE
Rvm from git

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
 source "http://api.berkshelf.com"
 
 metadata
+
+cookbook "rvm", git: 'https://github.com/fnichol/chef-rvm'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,3 +11,4 @@ default[:cypress][:queue_count] = 1
 default[:cypress][:queue_names] =  ["calculation"]
 override[:rvm][:group_users] = [default[:cypress][:user]]
 override[:rvm][:default_ruby] = default[:cypress][:ruby_version]
+override[:rvm][:gpg][:keyserver] = "hkp://keys.gnupg.net"


### PR DESCRIPTION
Install RVM from git, to fix some bugs that haven't been pushed to the gem yet.