### PR TITLE
Add secret keys generation

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,3 +15,4 @@ default[:cypress][:cvu_internal_port] = 8001
 default[:cypress][:cvu_external_port] = 8080
 default[:cypress][:cypress_git_revision] = 'master'
 default[:cypress][:cvu_git_revision] = 'master'
+default[:cypress][:generate_secrets_on_restart] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,3 +14,4 @@ default[:cypress][:cvu_install_path] = '/opt/cypress-validation-utility'
 default[:cypress][:cvu_internal_port] = 8001
 default[:cypress][:cvu_external_port] = 8080
 default[:cypress][:cypress_git_revision] = 'master'
+default[:cypress][:cvu_git_revision] = 'master'

--- a/files/default/regenerate-secrets.sh
+++ b/files/default/regenerate-secrets.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+secrets_file="$1"
+/bin/sed -i "s/[a-f0-9]\{32,128\}/$(hexdump -n 64 -e '/1 "%02x"' -e '/64 "\n"' /dev/urandom)/" "$secrets_file"

--- a/providers/install_app.rb
+++ b/providers/install_app.rb
@@ -112,6 +112,26 @@ action :create do
     only_if { new_resource.delayed_job }
   end
 
+  # Create secrets regeneration script (only happens when generate_secrets_on_restart is true)
+  cookbook_file '/opt/regenerate-secrets.sh' do
+    source "regenerate-secrets.sh"
+    mode "755"
+    only_if { new_resource.generate_secrets_on_restart }
+  end
+
+  template '/etc/systemd/system/regenerate-secrets.service' do
+    source "regenerate-secrets.service.erb"
+    variables({
+      :secrets_paths => ["#{install_path}/#{new_resource.secrets_path}"]
+    })
+    only_if { new_resource.generate_secrets_on_restart }
+  end
+
+  service "regenerate-secrets" do
+    action [:enable]
+    only_if { new_resource.generate_secrets_on_restart }
+  end
+
   service "nginx" do
     action :restart
   end

--- a/providers/install_app.rb
+++ b/providers/install_app.rb
@@ -122,7 +122,8 @@ action :create do
   template '/etc/systemd/system/regenerate-secrets.service' do
     source "regenerate-secrets.service.erb"
     variables({
-      :secrets_paths => ["#{install_path}/#{new_resource.secrets_path}"]
+      :service_names => [ install_path.split("/").last ],
+      :secrets_paths => [ "#{install_path}/#{new_resource.secrets_path}" ]
     })
     only_if { new_resource.generate_secrets_on_restart }
   end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,6 +37,10 @@ end
 template '/etc/systemd/system/regenerate-secrets.service' do
   source "regenerate-secrets.service.erb"
   variables({
+    :service_names => [
+      node[:cypress][:cypress_install_path].split("/").last,
+      node[:cypress][:cvu_install_path].split("/").last
+    ],
     :secrets_paths => [
       "#{node[:cypress][:cypress_install_path]}/config/secrets.yml",
       "#{node[:cypress][:cvu_install_path]}/config/secrets.yml"

--- a/recipes/install_cvu.rb
+++ b/recipes/install_cvu.rb
@@ -1,6 +1,8 @@
 cypress_install_app 'cypress-validation-utility' do
   application_path node[:cypress][:cvu_install_path]
   git_repository 'https://github.com/projectcypress/cypress-validation-utility.git'
+  git_revision node[:cypress][:cvu_git_revision]
   delayed_job false
   unicorn_port node[:cypress][:cvu_internal_port]
+  generate_secrets_on_restart node[:cypress][:generate_secrets_on_restart]
 end

--- a/recipes/install_cypress.rb
+++ b/recipes/install_cypress.rb
@@ -3,4 +3,5 @@ cypress_install_app 'cypress' do
   env_vars node[:cypress][:cypress_env_vars]
   git_revision node[:cypress][:cypress_git_revision]
   unicorn_port node[:cypress][:cypress_internal_port]
+  generate_secrets_on_restart node[:cypress][:generate_secrets_on_restart]
 end

--- a/resources/install_app.rb
+++ b/resources/install_app.rb
@@ -13,3 +13,5 @@ attribute :environment, :kind_of => String, :default => "production"
 attribute :application_path, :kind_of => String, :default => '/opt/cypress'
 attribute :delayed_job, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :env_vars, :kind_of => Hash, :default => {}
+attribute :secrets_path, :kind_of => String, :default => 'config/secrets.yml'
+attribute :generate_secrets_on_restart, :kind_of => [TrueClass, FalseClass], :default => false

--- a/templates/default/regenerate-secrets.service.erb
+++ b/templates/default/regenerate-secrets.service.erb
@@ -1,5 +1,8 @@
 [Unit]
 Description=Regenerate Cypress and CVU secret keys
+<% @service_names.each do |service| %>
+Before=<%= service %>.service
+<% end %>
 
 [Service]
 Type=oneshot

--- a/templates/default/regenerate-secrets.service.erb
+++ b/templates/default/regenerate-secrets.service.erb
@@ -1,0 +1,12 @@
+[Unit]
+Description=Regenerate Cypress and CVU secret keys
+
+[Service]
+Type=oneshot
+<% @secrets_paths.each do |secret_path| %>
+ExecStart=/opt/regenerate-secrets.sh <%= secret_path %>
+<% end %>
+ExecStartPost=/bin/systemctl disable regenerate-secrets.service
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This adds the ability for an option to be set which regenerates the secret_key_base on reboot (which is turned off by default, we turn it on from our packer scripts). This is so that the secret key in our distributed VM's is not the same for every VM since that would pose a security risk.