### PR TITLE
Add Unicorn Config

### DIFF
--- a/libraries/unicorn_config.rb
+++ b/libraries/unicorn_config.rb
@@ -1,0 +1,29 @@
+module UnicornConfig
+  # Subclass the resource.
+  class Resource < PoiseApplicationRuby::Resources::Unicorn::Resource
+    # Give it a new name so we can find it.
+    provides(:unicorn_config)
+    # Add a new property. Could do more here.
+    property(:port)
+    property(:config_path)
+  end
+
+  # Subclass the provider.
+  class Provider < PoiseApplicationRuby::Resources::Unicorn::Provider
+    # Match the name from above.
+    provides(:unicorn_config)
+
+    # Set service resource options.
+    def service_options(resource)
+      super
+      # Replace the command from the base class.
+      cmd = "unicorn --port #{new_resource.port}"
+      if new_resource.config_path and
+         ::File.exist?(::File.expand_path(new_resource.config_path, new_resource.path))
+        cmd << " --config-file #{::File.expand_path(new_resource.config_path, new_resource.path)}"
+      end
+      cmd << " #{configru_path}"
+      resource.ruby_command(cmd)
+    end
+  end
+end

--- a/providers/install_app.rb
+++ b/providers/install_app.rb
@@ -78,7 +78,9 @@ action :create do
       secret_token secret_key
       secrets_mode :yaml
     end
-    unicorn do
+    # Defined in libraries/unicorn_config.rb
+    unicorn_config do
+      config_path "config/unicorn.rb"
       port server_port
     end
   end


### PR DESCRIPTION
This adds a unicorn config subclass which will include a config file if the config file exists. The install_app LWRP has been updated to use unicorn_config, meaning as soon as config/unicorn.rb is added to the cypress repo then the chef scripts will begin including it in builds.