### PR TITLE
Add tests and disable huge pages

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,6 +20,9 @@ driver:
 provisioner:
   name: chef_zero
 
+verifier:
+  name: inspec
+
 platforms:
   - name: ubuntu/xenial64
     driver_config:

--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,6 @@
 source 'https://rubygems.org'
+
+gem 'test-kitchen'
+gem 'kitchen-vagrant'
+gem 'kitchen-inspec'
+gem 'berkshelf'

--- a/files/default/disable-transparent-hugepages.service
+++ b/files/default/disable-transparent-hugepages.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Disable Transparent Huge Pages
+Before=mongod.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c "/bin/echo "never" | tee /sys/kernel/mm/transparent_hugepage/enabled"
+ExecStart=/bin/sh -c "/bin/echo "never" | tee /sys/kernel/mm/transparent_hugepage/defrag"
+
+[Install]
+WantedBy=multi-user.target

--- a/providers/install_app.rb
+++ b/providers/install_app.rb
@@ -1,6 +1,11 @@
 action :create do
   install_path = new_resource.application_path
 
+  # Suggested by mongo (https://docs.mongodb.com/manual/tutorial/transparent-huge-pages/)
+  cookbook_file '/etc/systemd/system/disable-transparent-hugepages.service' do
+    source "disable-transparent-hugepages.service"
+  end
+
   user new_resource.user do
     supports :manage_home => true
     comment "#{new_resource.user} User"
@@ -41,6 +46,10 @@ action :create do
   # later time.
   cookbook_file '/etc/systemd/system/mongod.service' do
     source "mongod.service"
+  end
+
+  service "disable-transparent-hugepages" do
+    action [:start, :enable]
   end
 
   service "mongod" do

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,0 +1,41 @@
+describe service 'nginx' do
+  it { should be_installed }
+  it { should be_running }
+end
+
+describe service 'mongod' do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe service 'cypress' do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe service 'cypress-validation-utility' do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe command 'curl localhost/users/sign_in' do
+  its('stdout') { should match /Sign In/ }
+  its('stdout') { should match /Sign up/ }
+  its('stdout') { should match /Cypress/ }
+end
+
+describe port 80 do
+  it { should be_listening }
+end
+
+describe port 8080 do
+  it { should be_listening }
+end
+
+describe command 'cat /sys/kernel/mm/transparent_hugepage/enabled' do
+  its('stdout') { should match /\[never\]/ }
+end
+
+describe command 'cat /sys/kernel/mm/transparent_hugepage/defrag' do
+  its('stdout') { should match /\[never\]/ }
+end


### PR DESCRIPTION
This adds a basic test suite to the project which is run automatically when running `bundle exec kitchen test`. The next step would be to make this run for every pull request, the biggest issue being that using the vagrant driver on travis is not going to work, so it would require running the whole test suite against a docker container which should still be workable.

Also this adds automatic disabling of transparent hugepages on every boot of the machine provisioned by this chef script.