### PR TITLE
Lock down ruby version

### DIFF
--- a/resources/install_app.rb
+++ b/resources/install_app.rb
@@ -6,7 +6,7 @@ attribute :name, :kind_of => String
 attribute :user, :kind_of => String, :default => 'cypress'
 attribute :git_repository, :kind_of => String, :default => 'https://github.com/projectcypress/cypress.git'
 attribute :git_revision, :kind_of => String, :default => 'master'
-attribute :ruby_version, :kind_of => String, :default => '2.2'
+attribute :ruby_version, :kind_of => String, :default => '2.2.6'
 attribute :secret_key, :kind_of => String, :default => SecureRandom.hex(64)
 attribute :unicorn_port, :kind_of => Integer, :default => 8000
 attribute :environment, :kind_of => String, :default => "production"


### PR DESCRIPTION
Make sure our built versions build off a specific version, not just the 2.2 latest release. This is in conjunction with https://github.com/projectcypress/cypress/pull/817 in order to bring the two into sync.