### PR TITLE
Bump versions of dependencies

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,6 +12,7 @@
 ---
 driver:
   name: vagrant
+  require_chef_omnibus: 12.19
   customize:
     memory: 4096
     cpus: 4

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,8 +6,7 @@ description      'Installs/Configures Cypress'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.0.0'
 depends          "application_ruby", "~> 4.0"
-depends          "apt",              "~> 4.0"
-depends          "git",              "~> 4.6"
-depends          'nginx_passenger',  "~> 0.5.7"
-depends          "sudo",             "~> 2.11"
+depends          "apt",              "~> 6.1"
+depends          "git",              "~> 6.0"
+depends          "sudo",             "~> 3.3"
 depends          "poise-ruby-build", "~> 1.0"


### PR DESCRIPTION
It seems that all the latest versions do not break any functionality we use so I have updated to the latest version of all the dependent cookbooks. Unfortunately chef 13 changes a lot of stuff so we will need to stay on chef 12.19 for now. Good news is that version is still supported until at least next year so that is an upgrade we will probably want to push off.