### PR TITLE
Pin mongo version to 3.4.5

### DIFF
--- a/providers/install_app.rb
+++ b/providers/install_app.rb
@@ -40,9 +40,20 @@ action :create do
     end
   end
 
-  package "mongodb-org" do
-    action :install
-    version '3.4.5'
+  # Chef doesn't seem to provide a way to specify that the package should
+  # both be installed and locked to a version so we're iterating to
+  # solve that, this is temporary code anyway until the problems with mongo
+  # 3.4.6 are solved.
+  [ :install, :lock ].each do |install_action|
+    [
+      "mongodb-org-mongos", "mongodb-org-server",
+      "mongodb-org-shell", "mongodb-org-tools", "mongodb-org"
+    ].each do |pkg|
+      package pkg do
+        action install_action
+        version '3.4.5'
+      end
+    end
   end
 
   service "disable-transparent-hugepages" do

--- a/providers/install_app.rb
+++ b/providers/install_app.rb
@@ -33,11 +33,16 @@ action :create do
     "curl", "zlib1g", "zlib1g-dev", "libyaml-dev", "libsqlite3-dev",
     "sqlite3", "libxml2-dev", "libxslt-dev", "autoconf", "libc6-dev",
     "ncurses-dev", "automake", "libtool", "bison", "subversion",
-    "pkg-config", "libgmp3-dev", "nodejs", "g++", "mongodb-org", "nginx"
+    "pkg-config", "libgmp3-dev", "nodejs", "g++", "nginx"
   ].each do |pkg|
     package pkg do
       action :install
     end
+  end
+
+  package "mongodb-org" do
+    action :install
+    version '3.4.5'
   end
 
   service "disable-transparent-hugepages" do


### PR DESCRIPTION
This temporarily fixes mapreduce until mongo releases a new version with mapreduce support.