### PR TITLE
Bumped chef version to 12.21, and updated chefdk link accordingly

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,7 +12,7 @@
 ---
 driver:
   name: vagrant
-  require_chef_omnibus: 12.19
+  require_chef_omnibus: 12.21
   customize:
     memory: 4096
     cpus: 4

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This recipe has been tested to work on Ubuntu 16.04 using the following install 
 
     sudo apt-get update
     sudo apt-get -y install git-core wget
-    wget https://packages.chef.io/stable/ubuntu/12.04/chefdk_0.15.16-1_amd64.deb
+    wget https://packages.chef.io/files/stable/chefdk/1.5.0/ubuntu/16.04/chefdk_1.5.0-1_amd64.deb
     sudo dpkg -i chefdk_0.15.16-1_amd64.deb
     git clone https://github.com/projectcypress/cypress-recipe.git
     cd cypress-recipe


### PR DESCRIPTION
Turns out the package hold feature was a feature in Chef 12.16 and earlier. We were indirectly instructing users to install 12.12 since that is the version ChefDK was packaging. This bumps the version to 12.21 which is packaged with version 1.5.0 of the ChefDK and also bumps the version we are testing against to 12.21.