### PR TITLE
Bump Ruby version to 2.3.5 and use IPv4 address instead of localhost

### DIFF
--- a/resources/install_app.rb
+++ b/resources/install_app.rb
@@ -6,7 +6,7 @@ attribute :name, :kind_of => String
 attribute :user, :kind_of => String, :default => 'cypress'
 attribute :git_repository, :kind_of => String, :default => 'https://github.com/projectcypress/cypress.git'
 attribute :git_revision, :kind_of => String, :default => 'master'
-attribute :ruby_version, :kind_of => String, :default => '2.3.4'
+attribute :ruby_version, :kind_of => String, :default => '2.3.5'
 attribute :secret_key, :kind_of => String, :default => SecureRandom.hex(64)
 attribute :unicorn_port, :kind_of => Integer, :default => 8000
 attribute :environment, :kind_of => String, :default => "production"

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -1,10 +1,10 @@
 upstream primary {
-  server localhost:<%= @primary_app_port %>;
+  server 127.0.0.1:<%= @primary_app_port %>;
 }
 
 <% if @enable_secondary_app -%>
 upstream secondary {
-  server localhost:<%= @secondary_app_port %>;
+  server 127.0.0.1:<%= @secondary_app_port %>;
 }
 <% end -%>
 


### PR DESCRIPTION
The IPv4 change is in response to a ticket that was opened, it seems that sometimes localhost will resolve to the IPv6 address so just to be save I have hardcoded it to an IPv4 localhost address.