### PR TITLE
fix incorrect generation command

### DIFF
--- a/templates/default/regenerate-secrets.service.erb
+++ b/templates/default/regenerate-secrets.service.erb
@@ -7,7 +7,7 @@ Before=<%= service %>.service
 [Service]
 Type=oneshot
 <% @service_names.each do |service| %>
-ExecStart=/bin/sh -c "/usr/bin/<%= service %> config:set SECRET_KEY_BASE=$(/usr/bin/<%= service %> run rake secret)"
+ExecStart=/bin/sh -c "/usr/bin/<%= service %> config:set SECRET_KEY_BASE=$(/usr/bin/<%= service %> run rails secret)"
 <% end %>
 ExecStartPost=/bin/systemctl disable regenerate-secrets.service
 


### PR DESCRIPTION
Replaced `run rake secret` with `run rails secret`, as advised by Dave.


Pull requests into Cypress Recipe require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] You have tried to break the code
